### PR TITLE
Service creation test

### DIFF
--- a/MACS/src/app/services/test/test.service.spec.ts
+++ b/MACS/src/app/services/test/test.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { TestService } from './test.service';
+
+describe('TestService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [TestService]
+    });
+  });
+
+  it('should be created', inject([TestService], (service: TestService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/MACS/src/app/services/test/test.service.ts
+++ b/MACS/src/app/services/test/test.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class TestService {
+
+  constructor() { }
+
+}


### PR DESCRIPTION
Added test service into folder, syntax from /MACS: 

ng generate service services/test/test 

('services' is the name of the folder, 'test' will create another folder to house the 'test' service)